### PR TITLE
Fix-up docblock

### DIFF
--- a/src/scripts/hubot-redmine.coffee
+++ b/src/scripts/hubot-redmine.coffee
@@ -10,29 +10,15 @@
 #   HUBOT_REDMINE_SSL - Use "1" if your server uses SSL (https://)
 #
 # Commands:
-#   (redmine|show) me <issue-id>     - Show the issue status
-#   show (my|user's) issues          - Show your issues or another user's issues
-#   assign <issue-id> to <user-first-name> ["notes"]  - Assign the issue to the user (searches login or firstname)
-#   update <issue-id> with "<note>"  - Adds a note to the issue
-#   add <hours> hours to <issue-id> ["comments"]  - Adds hours to the issue with the optional comments
-#   link me <issue-id> - Returns a link to the redmine issue
-#   set <issue-id> to <int>% ["comments"] - Updates an issue and sets the percent done
+#   hubot (redmine|show) me <issue-id>     - Show the issue status
+#   hubot show (my|user's) issues          - Show your issues or another user's issues
+#   hubot assign <issue-id> to <user-first-name> ["notes"]  - Assign the issue to the user (searches login or firstname)
+#   hubot update <issue-id> with "<note>"  - Adds a note to the issue
+#   hubot add <hours> hours to <issue-id> ["comments"]  - Adds hours to the issue with the optional comments
+#   hubot link me <issue-id> - Returns a link to the redmine issue
+#   hubot set <issue-id> to <int>% ["comments"] - Updates an issue and sets the percent done
 #
-#---
-#
-# To get set up refer to the guide http://www.redmine.org/projects/redmine/wiki/Rest_api#Authentication
-# After that, heroku needs the following config
-#
-#   heroku config:add HUBOT_REDMINE_BASE_URL="http://redmine.your-server.com"
-#   heroku config:add HUBOT_REDMINE_TOKEN="your api token here"
-#
-# If you are using redmine over HTTPS, add the following config option
-#
-#   heroku config:add HUBOT_REDMINE_SSL=1
-#
-# There may be issues if you have a lot of redmine users sharing a first name, but this can be avoided
-# by using redmine logins rather than firstnames
-#
+
 if process.env.HUBOT_REDMINE_SSL?
   HTTP = require('https')
 else


### PR DESCRIPTION
Prior to this PR, the [hubot-help](https://github.com/hubot-scripts/hubot-help) command invoked by typing `hubot help` would output a lot of extra stuff that wasn't a command. This removes the setup instructions (no longer needed, covered by the README) and other notes.

### Not Good:

```
user> hubot help redmine
hubot> (redmine|show) me <issue-id>     - Show the issue status
hubot> If you are using redmine over HTTPS, add the following config option
hubot> There may be issues if you have a lot of redmine users sharing a first name, but this can be avoided
hubot> To get set up refer to the guide http://www.redmine.org/projects/redmine/wiki/Rest_api#Authentication
hubot> by using redmine logins rather than firstnames
hubot> heroku config:add ravenbot_REDMINE_BASE_URL="http://redmine.your-server.com"
hubot> heroku config:add ravenbot_REDMINE_SSL=1
hubot> heroku config:add ravenbot_REDMINE_TOKEN="your api token here"
hubot> link me <issue-id> - Returns a link to the redmine issue
```

### Better:

```
user> hubot help redmine
hubot> hubot (redmine|show) me <issue-id>     - Show the issue status
hubot> hubot link me <issue-id> - Returns a link to the redmine issue
```

Other commands are shown by searching for them:

```
user> hubot help hours
hubot> hubot add <hours> hours to <issue-id> ["comments"]  - Adds hours to the issue with the optional comments
```