### PR TITLE
Slightly more forgiving show username's regex

### DIFF
--- a/src/scripts/hubot-redmine.coffee
+++ b/src/scripts/hubot-redmine.coffee
@@ -77,12 +77,12 @@ module.exports = (robot) ->
         msg.reply "Nothing could be logged. Make sure RedMine has a default activity set for time tracking. (Settings -> Enumerations -> Activities)"
 
   # Robot show <my|user's> [redmine] issues
-  robot.respond /show (?:my|(\w+\'s)) (?:redmine )?issues/i, (msg) ->
+  robot.respond /show @?(?:my|(\w+\ ?'s)) (?:redmine )?issues/i, (msg) ->
     userMode = true
     firstName =
       if msg.match[1]?
         userMode = false
-        msg.match[1].replace(/\'.+/, '')
+        msg.match[1].replace(/\'.+/, '').trim()
       else
         msg.message.user.name.split(/\s/)[0]
 

--- a/src/scripts/hubot-redmine.coffee
+++ b/src/scripts/hubot-redmine.coffee
@@ -77,7 +77,7 @@ module.exports = (robot) ->
         msg.reply "Nothing could be logged. Make sure RedMine has a default activity set for time tracking. (Settings -> Enumerations -> Activities)"
 
   # Robot show <my|user's> [redmine] issues
-  robot.respond /show @?(?:my|(\w+\ ?'s)) (?:redmine )?issues/i, (msg) ->
+  robot.respond /show @?(?:my|(\w+\s?'s)) (?:redmine )?issues/i, (msg) ->
     userMode = true
     firstName =
       if msg.match[1]?


### PR DESCRIPTION
This can be useful for slack (maybe others). If I use the name auto-complete in slack I would get something like `@username 's`  The ` '` is from slack adding a space automatically. I can't think of any negative effects from this change.