### PR TITLE
Fix Spelling on status update 'In Porgress'

### DIFF
--- a/src/redmine.coffee
+++ b/src/redmine.coffee
@@ -168,7 +168,7 @@ module.exports = (robot) ->
       else
         status_id = 2
     else
-      status = "In Porgress"
+      status = "In Progress"
       status_id = 2
 
     attributes =


### PR DESCRIPTION
On line 171 of redmine.coffee there was a minor spelling error for the
robot.respond /starting response where it said 'In Porgress'.  I just set it to
'In Progress'. This is merely a cosmetic fix to the message.
