### PR TITLE
🐛 Do not require HUBOT_REDMINE_SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ user (preferably one with enough access to modify tickets), add the following to
     heroku config:add HUBOT_REDMINE_BASE_URL="http://redmine.your-server.com"
     heroku config:add HUBOT_REDMINE_TOKEN="your api token here"
 
-If using over SSL, add the following to your heroku config:
-
-    heroku config:add HUBOT_REDMINE_SSL=1
-
 ![screenshot](https://github.com/robhurring/hubot-redmine/blob/master/ss.png?raw=true)
 
 ## Installation

--- a/src/redmine.coffee
+++ b/src/redmine.coffee
@@ -7,7 +7,6 @@
 # Configuration:
 #   HUBOT_REDMINE_BASE_URL - URL to your Redmine install
 #   HUBOT_REDMINE_TOKEN - API key for your selected user
-#   HUBOT_REDMINE_SSL - Use "1" if your server uses SSL (https://)
 #
 # Commands:
 #   hubot (redmine|show) me <issue-id>     - Show the issue status
@@ -21,13 +20,13 @@
 #   hubot set <issue-id> to <int>% ["comments"] - Updates an issue and sets the percent done
 #
 
-if process.env.HUBOT_REDMINE_SSL?
+URL = require('url')
+QUERY = require('querystring')
+
+if URL.parse(process.env.HUBOT_REDMINE_BASE_URL).protocol == 'https:'
   HTTP = require('https')
 else
   HTTP = require('http')
-
-URL = require('url')
-QUERY = require('querystring')
 
 module.exports = (robot) ->
   redmine = new Redmine process.env.HUBOT_REDMINE_BASE_URL, process.env.HUBOT_REDMINE_TOKEN


### PR DESCRIPTION
Since we have the protocol in HUBOT_REDMINE_BASE_URL, we don't need to
ask people to configure an additional setting - we can just parse the
available URL. This simplifies configuration.