### PR TITLE
Add support for search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,10 @@ Then add **hubot-redmine** to your `external-scripts.json`:
 * Hubot set [issue id] to 100% "[comments]"
 * Hubot add [hours] hours to [issue id] "[comments]"
 
+## Search Redmine
+
+The default results limit is 10, configurable via `HUBOT_REDMINE_SEARCH_LIMIT`.
+
+* Hubot redmine search <query>
+
 ## More coming!

--- a/src/redmine.coffee
+++ b/src/redmine.coffee
@@ -268,6 +268,22 @@ module.exports = (robot) ->
 
       msg.reply _.join "\n"
 
+  # Robot redmine search <query>
+  robot.respond /(redmine search|search redmine) (.*)/i, (msg) ->
+    query = msg.match[2]
+    redmine.search query, (err, data) ->
+      if err?
+        msg.reply "Couldn't get search results!"
+        robot.logger.debug err
+      else
+        if data.total_count?
+          _ = []
+          for result in data.results
+            _.push "#{result.title} - #{result.url}"
+          msg.reply _.join "\n"
+        else
+          msg.reply "No search results for #{query}"
+
   # Chime in on ticket mentions.
   # Default requires double-backquote here but not in shell.
   mentions_regex = RegExp process.env.HUBOT_REDMINE_MENTION_REGEX or '#(\\d+)'
@@ -385,6 +401,9 @@ class Redmine
 
     create: (attributes, callback) =>
       @post "/time_entries.json", {time_entry: attributes}, callback
+
+  search: (term, callback) ->
+    @get "/search.json?q=#{encodeURI term}", {}, callback
 
   # Private: do a GET request against the API
   get: (path, params, callback) ->

--- a/src/redmine.coffee
+++ b/src/redmine.coffee
@@ -269,7 +269,7 @@ module.exports = (robot) ->
       msg.reply _.join "\n"
 
   # Robot redmine search <query>
-  robot.respond /(redmine search|search redmine) (.*)/i, (msg) ->
+  robot.respond /redmine search (.*)/i, (msg) ->
     query = msg.match[2]
     redmine.search query, (err, data) ->
       if err?

--- a/src/redmine.coffee
+++ b/src/redmine.coffee
@@ -280,6 +280,8 @@ module.exports = (robot) ->
           _ = []
           for result in data.results
             _.push "#{result.title} - #{result.url}"
+          if data.total_count > data.limit
+            _.push "More results: #{process.env.HUBOT_REDMINE_BASE_URL}/search?q=#{query}"
           msg.reply _.join "\n"
         else
           msg.reply "No search results for #{query}"

--- a/src/redmine.coffee
+++ b/src/redmine.coffee
@@ -270,7 +270,7 @@ module.exports = (robot) ->
 
   # Robot redmine search <query>
   robot.respond /redmine search (.*)/i, (msg) ->
-    query = msg.match[2]
+    query = msg.match[1]
     redmine.search query, (err, data) ->
       if err?
         msg.reply "Couldn't get search results!"

--- a/src/redmine.coffee
+++ b/src/redmine.coffee
@@ -403,7 +403,7 @@ class Redmine
       @post "/time_entries.json", {time_entry: attributes}, callback
 
   search: (term, callback) ->
-    @get "/search.json?q=#{encodeURI term}", {}, callback
+    @get "/search.json", { q: encodeURI term }, callback
 
   # Private: do a GET request against the API
   get: (path, params, callback) ->

--- a/test/redmine-test.coffee
+++ b/test/redmine-test.coffee
@@ -12,13 +12,13 @@ describe 'redmine', ->
 
     require('../src/redmine')(@robot)
 
-  it 'registers a add listener', ->
+  it 'registers a add hours to issue listener', ->
     expect(@robot.respond).to.have.been.calledWith(/add (\d{1,2}) hours? to (?:issue )?(?:#)?(\d+)(?: "?([^"]+)"?)?/i)
 
-  it 'registers a add listener', ->
+  it 'registers a add issue to tracker listener', ->
     expect(@robot.respond).to.have.been.calledWith(/add (?:issue )?(?:\s*to\s*)?(?:"?([^" ]+)"? )(?:tracker\s)?(\d+)?(?:\s*with\s*)("?([^"]+)"?)/i)
 
-  it 'registers a assign listener', ->
+  it 'registers a assign issue listener', ->
     expect(@robot.respond).to.have.been.calledWith(/assign (?:issue )?(?:#)?(\d+) to (\w+)(?: "?([^"]+)"?)?/i)
 
   it 'registers a link me listener', ->

--- a/test/redmine-test.coffee
+++ b/test/redmine-test.coffee
@@ -25,7 +25,7 @@ describe 'redmine', ->
     expect(@robot.respond).to.have.been.calledWith(/link me (?:issue )?(?:#)?(\d+)/i)
 
   it 'registers a search listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/(redmine search|search redmine) (.*)/i)
+    expect(@robot.respond).to.have.been.calledWith(/redmine search (.*)/i)
 
   it 'registers a set listener', ->
     expect(@robot.respond).to.have.been.calledWith(/set (?:issue )?(?:#)?(\d+) to (\d{1,3})%?(?: "?([^"]+)"?)?/i)

--- a/test/redmine-test.coffee
+++ b/test/redmine-test.coffee
@@ -24,6 +24,9 @@ describe 'redmine', ->
   it 'registers a link me listener', ->
     expect(@robot.respond).to.have.been.calledWith(/link me (?:issue )?(?:#)?(\d+)/i)
 
+  it 'registers a search listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/(redmine search|search redmine) (.*)/i)
+
   it 'registers a set listener', ->
     expect(@robot.respond).to.have.been.calledWith(/set (?:issue )?(?:#)?(\d+) to (\d{1,3})%?(?: "?([^"]+)"?)?/i)
 

--- a/test/redmine-test.coffee
+++ b/test/redmine-test.coffee
@@ -12,20 +12,8 @@ describe 'redmine', ->
 
     require('../src/redmine')(@robot)
 
-  it 'registers a link me listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/link me (?:issue )?(?:#)?(\d+)/i)
-
-  it 'registers a set listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/set (?:issue )?(?:#)?(\d+) to (\d{1,3})%?(?: "?([^"]+)"?)?/i)
-
   it 'registers a add listener', ->
     expect(@robot.respond).to.have.been.calledWith(/add (\d{1,2}) hours? to (?:issue )?(?:#)?(\d+)(?: "?([^"]+)"?)?/i)
-
-  it 'registers a show listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/show @?(?:my|(\w+\s?'?s?)) (?:redmine )?issues/i)
-
-  it 'registers a update listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/update (?:issue )?(?:#)?(\d+)(?:\s*with\s*)?(?:[-:,])? (?:"?([^"]+)"?)/i)
 
   it 'registers a add listener', ->
     expect(@robot.respond).to.have.been.calledWith(/add (?:issue )?(?:\s*to\s*)?(?:"?([^" ]+)"? )(?:tracker\s)?(\d+)?(?:\s*with\s*)("?([^"]+)"?)/i)
@@ -33,6 +21,17 @@ describe 'redmine', ->
   it 'registers a assign listener', ->
     expect(@robot.respond).to.have.been.calledWith(/assign (?:issue )?(?:#)?(\d+) to (\w+)(?: "?([^"]+)"?)?/i)
 
+  it 'registers a link me listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/link me (?:issue )?(?:#)?(\d+)/i)
+
+  it 'registers a set listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/set (?:issue )?(?:#)?(\d+) to (\d{1,3})%?(?: "?([^"]+)"?)?/i)
+
+  it 'registers a show listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/show @?(?:my|(\w+\s?'?s?)) (?:redmine )?issues/i)
+
   it 'registers a show listener', ->
     expect(@robot.respond).to.have.been.calledWith(/(?:redmine|show)(?: me)? (?:issue )?(?:#)?(\d+)/i)
- 
+
+  it 'registers a update listener', ->
+    expect(@robot.respond).to.have.been.calledWith(/update (?:issue )?(?:#)?(\d+)(?:\s*with\s*)?(?:[-:,])? (?:"?([^"]+)"?)/i)


### PR DESCRIPTION
Recent versions (3.3+?) of Redmine have `/search.json` which we can use to search.

    person> hubot redmine search haircut
    Support #236 (New): Limit member haircuts - https://redmine.example.org/issues/236
    Support #166 (Resolved): Change to haircut confirmation email - https://redmine.example.org/issues/166
    Support #124 (New): Mandatory name in haircut & display in CSV - https://redmine.example.org/issues/124
    Support #83 (Resolved): FW: Form submission from: Contact - https://redmine.example.org/issues/83
