### PR TITLE
Fix release script issue, mismatched package-lock.json file

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,9 @@
+{
+  "pkgFiles": ["package.json", "package-lock.json"],
+  "src": {
+    "tagName": "v%s"
+  },
+  "github": {
+    "release": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-redmine",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The `release-it` configuration script was not named correctly. This prevented the `package-lock.json` from being updated at the time.